### PR TITLE
Feat/implement note offset

### DIFF
--- a/.config/display.conf
+++ b/.config/display.conf
@@ -1,4 +1,4 @@
 {
-  "height": 1309,
-  "width": 1948
+  "height": 720,
+  "width": 1080
 }

--- a/.config/display.conf
+++ b/.config/display.conf
@@ -1,4 +1,4 @@
 {
-  "height": 720,
-  "width": 1080
+  "height": 1371,
+  "width": 2560
 }

--- a/.config/display.conf
+++ b/.config/display.conf
@@ -1,4 +1,4 @@
 {
-  "height": 720,
-  "width": 1080
+  "height": 1309,
+  "width": 1948
 }

--- a/include/application/Application.hpp
+++ b/include/application/Application.hpp
@@ -19,6 +19,8 @@ class Application {
 
     float _lastTime;
 
+    float _framesPerSecond;
+
     void update();
 
     void render();

--- a/include/engine/mesh/Mesh.hpp
+++ b/include/engine/mesh/Mesh.hpp
@@ -12,14 +12,20 @@ class Mesh {
 
     void initialise(GLenum primitive, GLenum usage);
 
+    void setColours(std::vector<float> colours);
+
     void setVertices(std::vector<float> vertices);
+
     void setIndices(std::vector<unsigned int> indices);
 
     void setPrimitive(GLenum primitive);
 
     void setUsage(GLenum usage);
 
+    std::vector<float> &getColours();
+
     std::vector<float> &getVertices();
+
     std::vector<unsigned int> &getIndices();
 
     GLenum getPrimitive();
@@ -28,15 +34,23 @@ class Mesh {
 
     GLuint getVao();
 
+    GLuint getCbo();
+
     std::size_t getVertexCount();
+
     std::size_t getIndexCount();
 
+    std::size_t getColourCount();
+
   private:
+    std::vector<float> _colours;
     std::vector<float> _vertices;
+
     std::vector<unsigned int> _indices;
 
     std::size_t _vertexCount;
     std::size_t _indexCount;
+    std::size_t _colourCount;
 
     GLenum _primitive;
 
@@ -44,6 +58,7 @@ class Mesh {
 
     GLuint _vao;
     GLuint _vbo;
+    GLuint _cbo;
     GLuint _ebo;
 
     bool _isInitialised;

--- a/include/engine/sound/SoundBuffer.hpp
+++ b/include/engine/sound/SoundBuffer.hpp
@@ -25,15 +25,15 @@ class SoundBuffer {
 
     ~SoundBuffer();
 
-    short *getMemoryBuffer(const SF_INFO &soundFileInfo);
+    float *getMemoryBuffer(const SF_INFO &soundFileInfo);
 
     bool setSoundFile(const char *soundPath, SNDFILE *&soundFile, SF_INFO &soundFileInfo);
 
     bool setSoundFormat(ALenum &format, SNDFILE *soundFile, const SF_INFO &soundFileInfo);
 
-    bool setNumberOfFrames(sf_count_t &numberOfFrames, SNDFILE *soundFile, const SF_INFO &soundFileInfo, short *memoryBuffer);
+    bool setNumberOfFrames(sf_count_t &numberOfFrames, SNDFILE *soundFile, const SF_INFO &soundFileInfo, float *memoryBuffer);
 
-    bool setSoundBuffer(ALuint &soundBuffer, SNDFILE *soundFile, const SF_INFO &soundFileInfo, ALenum &format, sf_count_t &numberOfFrames, short *memoryBuffer);
+    bool setSoundBuffer(ALuint &soundBuffer, SNDFILE *soundFile, const SF_INFO &soundFileInfo, ALenum &format, sf_count_t &numberOfFrames, float *memoryBuffer);
 
     bool isSoundError(ALuint soundBuffer);
 

--- a/include/engine/sound/SoundSource.hpp
+++ b/include/engine/sound/SoundSource.hpp
@@ -13,7 +13,7 @@ class SoundSource {
     void play(const ALuint soundBuffer);
 
   private:
-    static constexpr float _GAIN = 1.0f;
+    static constexpr float _GAIN = 0.3f;
     static constexpr float _PITCH = 1.0f;
 
     static constexpr float _POSITION[3] = {0, 0, 0};

--- a/include/engine/sound/SoundSource.hpp
+++ b/include/engine/sound/SoundSource.hpp
@@ -13,7 +13,7 @@ class SoundSource {
     void play(const ALuint soundBuffer);
 
   private:
-    static constexpr float _GAIN = 0.3f;
+    static constexpr float _GAIN = 0.5f;
     static constexpr float _PITCH = 1.0f;
 
     static constexpr float _POSITION[3] = {0, 0, 0};

--- a/include/parser/beatmap/BeatmapParser.hpp
+++ b/include/parser/beatmap/BeatmapParser.hpp
@@ -3,6 +3,7 @@
 #include <parser/Parser.hpp>
 
 #include <parser/beatmap/HitObject.hpp>
+#include <parser/beatmap/TimingPoint.hpp>
 
 namespace parser::beatmap {
 
@@ -14,14 +15,25 @@ class BeatmapParser final : public Parser {
 
     std::vector<HitObject> getHitObjects();
 
+    std::vector<TimingPoint> getTimingPoints();
+
   private:
     static constexpr int _HIT_OBJECT_IGNORE_FLAGS = 0b1010000;
+    static constexpr int _TIMING_POINT_IGNORE_FLAGS = 0b10111000;
 
     std::vector<HitObject> _hitObjects;
 
-    std::vector<int> getHitObjectValues(const std::string &line);
+    std::vector<TimingPoint> _timingPoints;
+
+    std::vector<std::string> getHitObjectValues(const std::string &line);
+
+    std::vector<std::string> getTimingPointValues(const std::string &line);
+
+    void parseLine(const std::string &line, std::ifstream &file);
 
     void addHitObjects(std::ifstream &file);
+
+    void addTimingPoints(std::ifstream &file);
 };
 
 } // namespace parser::beatmap

--- a/include/parser/beatmap/TimingPoint.hpp
+++ b/include/parser/beatmap/TimingPoint.hpp
@@ -3,6 +3,7 @@
 namespace parser::beatmap {
 
 class TimingPoint {
+  public:
     TimingPoint(int time, float beatLength, int meter, bool isInherited);
 
     int getTime();

--- a/include/parser/beatmap/TimingPoint.hpp
+++ b/include/parser/beatmap/TimingPoint.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace parser::beatmap {
+
+class TimingPoint {
+    TimingPoint(int time, float beatLength, int meter, bool isInherited);
+
+    int getTime();
+
+    int getMeter();
+
+    float getBeatLength();
+
+    bool isInherited();
+
+  private:
+    int _time;
+    int _meter;
+
+    float _beatLength;
+
+    bool _isInherited;
+};
+
+} // namespace parser::beatmap

--- a/include/utility/string/StringUtility.hpp
+++ b/include/utility/string/StringUtility.hpp
@@ -7,6 +7,8 @@ namespace utility::string {
 class StringUtility {
   public:
     static std::string trim(std::string string);
+
+    static bool stob(std::string string);
 };
 
 } // namespace utility::string

--- a/shaders/game/singleplayer/play/play.frag
+++ b/shaders/game/singleplayer/play/play.frag
@@ -5,7 +5,5 @@ in vec3 fColour;
 out vec4 oFragmentColour;
 
 void main() {
-    vec3 g = vec3(0.0f, 1.0f, 0.0f);
-
     oFragmentColour = vec4(fColour, 1.0f);
 }

--- a/shaders/game/singleplayer/play/play.frag
+++ b/shaders/game/singleplayer/play/play.frag
@@ -1,7 +1,11 @@
 #version 330 core
 
+in vec3 fColour;
+
 out vec4 oFragmentColour;
 
 void main() {
-    oFragmentColour = vec4(0.0f, 1.0f, 0.0f, 1.0f);
+    vec3 g = vec3(0.0f, 1.0f, 0.0f);
+
+    oFragmentColour = vec4(fColour, 1.0f);
 }

--- a/shaders/game/singleplayer/play/play.vert
+++ b/shaders/game/singleplayer/play/play.vert
@@ -1,10 +1,15 @@
 #version 330 core
 
 layout(location = 0) in vec3 iPosition;
+layout(location = 1) in vec3 iColour;
 
 uniform mat4 uModel;
 uniform mat4 uProjection;
 
+out vec3 fColour;
+
 void main() {
+    fColour = iColour;
+
     gl_Position = uProjection * uModel * vec4(iPosition, 1.0);
 }

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -97,7 +97,7 @@ void Application::update() {
     ++this->_framesPerSecond;
 
     if (deltaTime >= 1.0f) {
-        LOG_DEBUG("FPS: {}", this->_framesPerSecond);
+        // LOG_DEBUG("FPS: {}", this->_framesPerSecond);
 
         this->_framesPerSecond = 0.0f;
 

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -10,6 +10,8 @@
 
 #include <configuration/display/DisplayConfiguration.hpp>
 
+#include <logger/LoggerMacros.hpp>
+
 #include <iostream>
 
 using namespace manager;
@@ -22,7 +24,8 @@ using namespace application::game::singleplayer::play;
 
 namespace application {
 
-Application::Application() = default;
+Application::Application() : _lastTime(0.0f), _framesPerSecond(0.0f) {
+}
 
 void Application::initialise() {
     glfwInit();
@@ -74,8 +77,6 @@ void Application::load() {
 }
 
 void Application::run() {
-    this->_lastTime = 0.0f;
-
     while (!glfwWindowShouldClose(this->_window)) {
         this->update();
 
@@ -93,11 +94,19 @@ void Application::update() {
 
     float deltaTime = time - this->_lastTime;
 
+    ++this->_framesPerSecond;
+
+    if (deltaTime >= 1.0f) {
+        LOG_DEBUG("FPS: {}", this->_framesPerSecond);
+
+        this->_framesPerSecond = 0.0f;
+
+        this->_lastTime = time;
+    }
+
     Scene &scene = SceneManager::getInstance().getScene();
 
     scene.update(deltaTime);
-
-    this->_lastTime = time;
 }
 
 void Application::render() {

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -34,7 +34,7 @@ void Application::initialise() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-    GLFWwindow *window = glfwCreateWindow(1080, 720, "Ducky Jam", nullptr, nullptr);
+    GLFWwindow *window = glfwCreateWindow(1920, 1080, "Ducky Jam", nullptr, nullptr);
 
     if (window == nullptr) {
         std::cout << "Failed to create window" << std::endl;
@@ -77,6 +77,8 @@ void Application::load() {
 }
 
 void Application::run() {
+    glfwSwapInterval(1);
+
     while (!glfwWindowShouldClose(this->_window)) {
         this->update();
 

--- a/src/application/game/singleplayer/play/Play.cpp
+++ b/src/application/game/singleplayer/play/Play.cpp
@@ -16,8 +16,8 @@ Play::Play() : Scene() {
 }
 
 void Play::initialise() {
-    ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/2325151/4983858/bgm.mp3");
-    // ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/1831596/3759718/bgm.mp3");
+    ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/421541/948777/bgm.mp3");
+    // ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/2325151/4983858/bgm.mp3");
 
     this->_source.play(soundId);
 
@@ -31,7 +31,8 @@ void Play::initialise() {
 
     this->create();
 
-    this->load("data/beatmaps/2325151/4983858/beatmap.osu");
+    this->load("data/beatmaps/421541/948777/beatmap.osu");
+    // this->load("data/beatmaps/2325151/4983858/beatmap.osu");
 }
 
 void Play::create() {

--- a/src/application/game/singleplayer/play/Play.cpp
+++ b/src/application/game/singleplayer/play/Play.cpp
@@ -16,7 +16,8 @@ Play::Play() : Scene() {
 }
 
 void Play::initialise() {
-    ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/1831596/3759718/bgm.mp3");
+    ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/2325151/4983858/bgm.mp3");
+    // ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/1831596/3759718/bgm.mp3");
 
     this->_source.play(soundId);
 
@@ -30,7 +31,7 @@ void Play::initialise() {
 
     this->create();
 
-    this->load("data/beatmaps/1831596/3759718/beatmap.osu");
+    this->load("data/beatmaps/2325151/4983858/beatmap.osu");
 }
 
 void Play::create() {

--- a/src/application/game/singleplayer/play/Play.cpp
+++ b/src/application/game/singleplayer/play/Play.cpp
@@ -16,8 +16,9 @@ Play::Play() : Scene() {
 }
 
 void Play::initialise() {
-    ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/421541/948777/bgm.mp3");
+    // ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/421541/948777/bgm.mp3");
     // ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/2325151/4983858/bgm.mp3");
+    ALuint soundId = SoundBuffer::getInstance().addSound("data/beatmaps/974689/2220863/bgm.mp3");
 
     this->_source.play(soundId);
 
@@ -31,8 +32,9 @@ void Play::initialise() {
 
     this->create();
 
-    this->load("data/beatmaps/421541/948777/beatmap.osu");
+    // this->load("data/beatmaps/421541/948777/beatmap.osu");
     // this->load("data/beatmaps/2325151/4983858/beatmap.osu");
+    this->load("data/beatmaps/974689/2220863/beatmap.osu");
 }
 
 void Play::create() {

--- a/src/component/game/singleplayer/play/area/Area.cpp
+++ b/src/component/game/singleplayer/play/area/Area.cpp
@@ -22,6 +22,8 @@ void Area::load(const std::string &beatmapPath) {
 
     std::vector<HitObject> hitObjects = this->_beatmapParser.getHitObjects();
 
+    std::vector<TimingPoint> timingPoints = this->_beatmapParser.getTimingPoints();
+
     // Get the correct height offset based on the skin height, fps, scroll speed, bpm, and start time
     // for (HitObject &hitObject : hitObjects) {
     float scrollSpeed = 15.0f;
@@ -34,6 +36,7 @@ void Area::load(const std::string &beatmapPath) {
 
     // Suppose fps = 60hz, then scrollSpeed*fps=px/s or 1px/(1/60)ms
     // y = 1*60, 60px/second
+    float offset = pxPerMs * fps;
 
     for (HitObject &hitObject : hitObjects) {
         int lane = hitObject.getLane();
@@ -41,7 +44,7 @@ void Area::load(const std::string &beatmapPath) {
         int startTime = hitObject.getStartTime();
 
         float x = lane * width;
-        float y = pxPerMs * startTime;
+        float y = pxPerMs * startTime + offset;
 
         std::unique_ptr<Note> note = std::make_unique<Note>(x, y, 128.0f, 48.0f);
 

--- a/src/component/game/singleplayer/play/area/Area.cpp
+++ b/src/component/game/singleplayer/play/area/Area.cpp
@@ -26,7 +26,7 @@ void Area::load(const std::string &beatmapPath) {
 
     // Get the correct height offset based on the skin height, fps, scroll speed, bpm, and start time
     // for (HitObject &hitObject : hitObjects) {
-    float scrollSpeed = 15.0f;
+    float scrollSpeed = 20.0f;
 
     float fps = 155.0f;
 
@@ -42,11 +42,14 @@ void Area::load(const std::string &beatmapPath) {
         int lane = hitObject.getLane();
 
         int startTime = hitObject.getStartTime();
+        int endTime = hitObject.getEndTime();
 
         float x = lane * width;
-        float y = pxPerMs * startTime + offset;
+        float y = pxPerMs * startTime;
 
-        std::unique_ptr<Note> note = std::make_unique<Note>(x, y, 128.0f, 48.0f);
+        float height = (endTime == 0) ? 48.0f : (endTime - startTime) * pxPerMs;
+
+        std::unique_ptr<Note> note = std::make_unique<Note>(x, y, 128.0f, height);
 
         this->_lanes[lane]->addNote(std::move(note));
     }
@@ -59,7 +62,7 @@ void Area::update(float deltaTime) {
         lane->update(deltaTime);
     }
 
-    this->_noteModel = glm::translate(this->_noteModel, glm::vec3(0.0f, -15.0f, 0.0f));
+    this->_noteModel = glm::translate(this->_noteModel, glm::vec3(0.0f, -20.0f, 0.0f));
 }
 
 void Area::generateMesh() {

--- a/src/component/game/singleplayer/play/area/Area.cpp
+++ b/src/component/game/singleplayer/play/area/Area.cpp
@@ -24,7 +24,7 @@ void Area::load(const std::string &beatmapPath) {
 
     // Get the correct height offset based on the skin height, fps, scroll speed, bpm, and start time
     // for (HitObject &hitObject : hitObjects) {
-    float scrollSpeed = 10.0f;
+    float scrollSpeed = 15.0f;
 
     float fps = 155.0f;
 
@@ -56,7 +56,7 @@ void Area::update(float deltaTime) {
         lane->update(deltaTime);
     }
 
-    this->_noteModel = glm::translate(this->_noteModel, glm::vec3(0.0f, -10.0f, 0.0f));
+    this->_noteModel = glm::translate(this->_noteModel, glm::vec3(0.0f, -15.0f, 0.0f));
 }
 
 void Area::generateMesh() {

--- a/src/component/game/singleplayer/play/area/Area.cpp
+++ b/src/component/game/singleplayer/play/area/Area.cpp
@@ -72,6 +72,7 @@ void Area::generateMesh() {
 void Area::generateNoteMesh() {
     this->_noteMesh.initialise(GL_TRIANGLES, GL_DYNAMIC_DRAW);
 
+    std::vector<float> colours;
     std::vector<float> vertices;
     std::vector<unsigned int> indices;
 
@@ -94,6 +95,8 @@ void Area::generateNoteMesh() {
 
     size_t offset = 0;
 
+    int laneIndex = 0;
+
     for (std::unique_ptr<Lane> &lane : this->_lanes) {
         std::vector<std::unique_ptr<Note>> &notes = lane->getNotes();
 
@@ -104,6 +107,30 @@ void Area::generateNoteMesh() {
             const std::vector<unsigned int> &noteIndices = shapes[0]->getIndices();
 
             vertices.insert(vertices.end(), noteVertices.begin(), noteVertices.end());
+            glm::vec3 laneColour;
+
+            switch (laneIndex) {
+            case 0:
+            case 2:
+            case 4:
+            case 6:
+                laneColour = {1.0f, 1.0f, 1.0f}; // white
+                break;
+            case 1:
+            case 5:
+                laneColour = {0.208f, 0.784f, 1.0f}; // blue
+                break;
+            case 3:
+                laneColour = {0.996f, 0.827f, 0.212f}; // yellow
+                break;
+            }
+
+            size_t nVerts = noteVertices.size() / 3;
+            for (size_t v = 0; v < nVerts; ++v) {
+                colours.push_back(laneColour.r);
+                colours.push_back(laneColour.g);
+                colours.push_back(laneColour.b);
+            }
 
             for (unsigned int index : noteIndices) {
                 indices.push_back(index + offset);
@@ -111,10 +138,12 @@ void Area::generateNoteMesh() {
 
             offset += noteVertices.size() / 3;
         }
+        ++laneIndex;
     }
 
     this->_noteMesh.setVertices(vertices);
     this->_noteMesh.setIndices(indices);
+    this->_noteMesh.setColours(colours);
 }
 
 Mesh &Area::getNoteMesh() {

--- a/src/component/game/singleplayer/play/area/Area.cpp
+++ b/src/component/game/singleplayer/play/area/Area.cpp
@@ -10,7 +10,7 @@ Area::Area() : _noteModel(glm::mat4(1.0f)) {
 }
 
 void Area::create() {
-    for (int i = 0; i < 1; i++) {
+    for (int i = 0; i < 7; i++) {
         std::unique_ptr<Lane> lane = std::make_unique<Lane>();
 
         this->_lanes.push_back(std::move(lane));
@@ -24,12 +24,28 @@ void Area::load(const std::string &beatmapPath) {
 
     // Get the correct height offset based on the skin height, fps, scroll speed, bpm, and start time
     // for (HitObject &hitObject : hitObjects) {
-    for (int i = 0; i < 1; i++) {
-        // int lane = hitObject.getLane();
+    float scrollSpeed = 10.0f;
 
-        std::unique_ptr<Note> note = std::make_unique<Note>(0.0f, 0.0f, 128.0f, 48.0f);
+    float fps = 155.0f;
 
-        this->_lanes[0]->addNote(std::move(note));
+    float pxPerMs = fps * scrollSpeed * 0.001f;
+
+    float width = 128.0f;
+
+    // Suppose fps = 60hz, then scrollSpeed*fps=px/s or 1px/(1/60)ms
+    // y = 1*60, 60px/second
+
+    for (HitObject &hitObject : hitObjects) {
+        int lane = hitObject.getLane();
+
+        int startTime = hitObject.getStartTime();
+
+        float x = lane * width;
+        float y = pxPerMs * startTime;
+
+        std::unique_ptr<Note> note = std::make_unique<Note>(x, y, 128.0f, 48.0f);
+
+        this->_lanes[lane]->addNote(std::move(note));
     }
 
     generateMesh();
@@ -40,7 +56,7 @@ void Area::update(float deltaTime) {
         lane->update(deltaTime);
     }
 
-    this->_noteModel = glm::translate(this->_noteModel, glm::vec3(0.0f, 1.0f, 0.0f));
+    this->_noteModel = glm::translate(this->_noteModel, glm::vec3(0.0f, -10.0f, 0.0f));
 }
 
 void Area::generateMesh() {

--- a/src/engine/mesh/Mesh.cpp
+++ b/src/engine/mesh/Mesh.cpp
@@ -16,6 +16,7 @@ void Mesh::initialise(GLenum primitive, GLenum usage) {
     glGenVertexArrays(1, &this->_vao);
 
     glGenBuffers(1, &this->_vbo);
+    glGenBuffers(1, &this->_cbo);
     glGenBuffers(1, &this->_ebo);
 
     glBindVertexArray(this->_vao);

--- a/src/engine/mesh/Mesh.cpp
+++ b/src/engine/mesh/Mesh.cpp
@@ -2,13 +2,7 @@
 
 namespace engine::mesh {
 
-Mesh::Mesh() {
-    this->_vertexCount = 0;
-
-    this->_indexCount = 0;
-
-    this->_isInitialised = false;
-};
+Mesh::Mesh() : _vertexCount(0), _indexCount(0), _colourCount(0), _isInitialised(false) {};
 
 void Mesh::initialise(GLenum primitive, GLenum usage) {
     if (this->_isInitialised) {
@@ -29,17 +23,36 @@ void Mesh::initialise(GLenum primitive, GLenum usage) {
     glBindBuffer(GL_ARRAY_BUFFER, this->_vbo);
     glBufferData(GL_ARRAY_BUFFER, 0, nullptr, usage);
 
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->_ebo);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, 0, nullptr, usage);
-
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)0);
     glEnableVertexAttribArray(0);
+
+    glBindBuffer(GL_ARRAY_BUFFER, this->_cbo);
+    glBufferData(GL_ARRAY_BUFFER, 0, nullptr, usage);
+
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)0);
+    glEnableVertexAttribArray(1);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->_ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, 0, nullptr, usage);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     glBindVertexArray(0);
 
     this->_isInitialised = true;
+}
+
+void Mesh::setColours(std::vector<float> colours) {
+    this->_colours = colours;
+
+    size_t colourCount = colours.size();
+
+    glBindBuffer(GL_ARRAY_BUFFER, this->_cbo);
+    glBufferData(GL_ARRAY_BUFFER, colourCount * sizeof(float), colours.data(), this->_usage);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    this->_colourCount = colourCount;
 }
 
 void Mesh::setVertices(std::vector<float> vertices) {
@@ -74,6 +87,10 @@ void Mesh::setUsage(GLenum usage) {
     this->_usage = usage;
 }
 
+std::vector<float> &Mesh::getColours() {
+    return this->_colours;
+}
+
 std::vector<float> &Mesh::getVertices() {
     return this->_vertices;
 }
@@ -94,12 +111,20 @@ GLuint Mesh::getVao() {
     return this->_vao;
 }
 
+GLuint Mesh::getCbo() {
+    return this->_cbo;
+}
+
 std::size_t Mesh::getVertexCount() {
     return this->_vertexCount;
 }
 
 std::size_t Mesh::getIndexCount() {
     return this->_indexCount;
+}
+
+std::size_t Mesh::getColourCount() {
+    return this->_colourCount;
 }
 
 } // namespace engine::mesh

--- a/src/engine/sound/SoundBuffer.cpp
+++ b/src/engine/sound/SoundBuffer.cpp
@@ -39,7 +39,7 @@ ALuint SoundBuffer::addSound(const char *soundPath) {
         return 0;
     }
 
-    short *memoryBuffer = this->getMemoryBuffer(soundFileInfo);
+    float *memoryBuffer = this->getMemoryBuffer(soundFileInfo);
 
     sf_count_t numberOfFrames;
 
@@ -68,14 +68,14 @@ bool SoundBuffer::removeSound(const ALuint &sound) {
     return false;
 }
 
-short *SoundBuffer::getMemoryBuffer(const SF_INFO &soundFileInfo) {
+float *SoundBuffer::getMemoryBuffer(const SF_INFO &soundFileInfo) {
     int channels = soundFileInfo.channels;
 
     sf_count_t frames = soundFileInfo.frames;
 
-    size_t memoryBufferSize = (size_t)(frames * channels) * sizeof(short);
+    size_t memoryBufferSize = (size_t)(frames * channels) * sizeof(float);
 
-    return static_cast<short *>(malloc(memoryBufferSize));
+    return static_cast<float *>(malloc(memoryBufferSize));
 }
 
 bool SoundBuffer::setSoundFile(const char *soundPath, SNDFILE *&soundFile, SF_INFO &soundFileInfo) {
@@ -91,7 +91,7 @@ bool SoundBuffer::setSoundFile(const char *soundPath, SNDFILE *&soundFile, SF_IN
 
     sf_count_t frames = soundFileInfo.frames;
 
-    unsigned long maxFrames = INT_MAX / (sizeof(short) * channels);
+    auto maxFrames = INT_MAX / (sizeof(float) * channels);
 
     if (frames < 1 || frames > maxFrames) {
         LOG_ERROR("Bad sample count in {} {}", soundPath, frames);
@@ -109,16 +109,16 @@ bool SoundBuffer::setSoundFormat(ALenum &format, SNDFILE *soundFile, const SF_IN
 
     switch (channels) {
     case 1:
-        format = AL_FORMAT_MONO16;
+        format = AL_FORMAT_MONO_FLOAT32;
 
         return true;
     case 2:
-        format = AL_FORMAT_STEREO16;
+        format = AL_FORMAT_STEREO_FLOAT32;
 
         return true;
     case 3:
         if (sf_command(soundFile, SFC_WAVEX_GET_AMBISONIC, nullptr, 0) == SF_AMBISONIC_B_FORMAT) {
-            format = AL_FORMAT_BFORMAT2D_16;
+            format = AL_FORMAT_BFORMAT2D_FLOAT32;
 
             return true;
         }
@@ -126,7 +126,7 @@ bool SoundBuffer::setSoundFormat(ALenum &format, SNDFILE *soundFile, const SF_IN
         break;
     case 4:
         if (sf_command(soundFile, SFC_WAVEX_GET_AMBISONIC, nullptr, 0) == SF_AMBISONIC_B_FORMAT) {
-            format = AL_FORMAT_BFORMAT3D_16;
+            format = AL_FORMAT_BFORMAT3D_FLOAT32;
 
             return true;
         }
@@ -143,8 +143,8 @@ bool SoundBuffer::setSoundFormat(ALenum &format, SNDFILE *soundFile, const SF_IN
     return false;
 }
 
-bool SoundBuffer::setNumberOfFrames(sf_count_t &numberOfFrames, SNDFILE *soundFile, const SF_INFO &soundFileInfo, short *memoryBuffer) {
-    numberOfFrames = sf_readf_short(soundFile, memoryBuffer, soundFileInfo.frames);
+bool SoundBuffer::setNumberOfFrames(sf_count_t &numberOfFrames, SNDFILE *soundFile, const SF_INFO &soundFileInfo, float *memoryBuffer) {
+    numberOfFrames = sf_readf_float(soundFile, memoryBuffer, soundFileInfo.frames);
 
     if (numberOfFrames < 1) {
         free(memoryBuffer);
@@ -159,8 +159,8 @@ bool SoundBuffer::setNumberOfFrames(sf_count_t &numberOfFrames, SNDFILE *soundFi
     return true;
 }
 
-bool SoundBuffer::setSoundBuffer(ALuint &soundBuffer, SNDFILE *soundFile, const SF_INFO &soundFileInfo, ALenum &format, sf_count_t &numberOfFrames, short *memoryBuffer) {
-    ALsizei numberOfBytes = (ALsizei)(numberOfFrames * soundFileInfo.channels) * (ALsizei)sizeof(short);
+bool SoundBuffer::setSoundBuffer(ALuint &soundBuffer, SNDFILE *soundFile, const SF_INFO &soundFileInfo, ALenum &format, sf_count_t &numberOfFrames, float *memoryBuffer) {
+    ALsizei numberOfBytes = (ALsizei)(numberOfFrames * soundFileInfo.channels) * (ALsizei)sizeof(float);
 
     soundBuffer = 0;
 

--- a/src/parser/beatmap/TimingPoint.cpp
+++ b/src/parser/beatmap/TimingPoint.cpp
@@ -1,0 +1,24 @@
+#include <parser/beatmap/TimingPoint.hpp>
+
+namespace parser::beatmap {
+
+TimingPoint::TimingPoint(int time, float beatLength, int meter, bool isInherited) : _time(time), _beatLength(beatLength), _meter(meter), _isInherited(isInherited) {
+}
+
+int TimingPoint::getTime() {
+    return this->_time;
+}
+
+int TimingPoint::getMeter() {
+    return this->_meter;
+}
+
+float TimingPoint::getBeatLength() {
+    return this->_beatLength;
+}
+
+bool TimingPoint::isInherited() {
+    return this->_isInherited;
+}
+
+} // namespace parser::beatmap

--- a/src/utility/string/StringUtility.cpp
+++ b/src/utility/string/StringUtility.cpp
@@ -10,4 +10,8 @@ std::string StringUtility::trim(std::string string) {
     return string;
 }
 
+bool StringUtility::stob(std::string string) {
+    return string == "1";
+}
+
 } // namespace utility::string


### PR DESCRIPTION
## Description
- Created note offset
- Resolves #17 

## Solution
- Naive solution was to use:
```math
y=\frac{fps}{1000}\times v\times t
```
Where $v$ is the scroll speed and $t$ is the start time (in ms). For example, given $fps=60hz$, and given $v=1.0f$, then we expect each note to move at $fps\times v$ pixels per second, since each frame it moves by $1.0f=1$ pixel per frame. Now, given $t=32000 ms$ (32000 milli seconds), the position of y position of the note is at $y=\frac{60/1000}\times 1.0\times 32000=1920 px$

### Problems
- This only works assuming our engine runs `x fps` consistently. As CPU computation and VRAM usage increases, we expect fps drops, making this a temporary solution.

## Next Steps
- Optimise audio engine
- Optimise rendering